### PR TITLE
Workaround to fix pdf artifacts

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
-function generateMarkerSvg(width, height, bits) {
+function generateMarkerSvg(width, height, bits, fixPdfArtifacts = true) {
 	var svg = document.createElement('svg');
 	svg.setAttribute('viewBox', '0 0 ' + (width + 2) + ' ' + (height + 2));
 	svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-	svg.setAttribute('shape-rendering', 'crispEdges'); // disable anti-aliasing to avoid little gaps between rects
+	svg.setAttribute('shape-rendering', 'crispEdges');
 
 	// Background rect
 	var rect = document.createElement('rect');
@@ -16,14 +16,32 @@ function generateMarkerSvg(width, height, bits) {
 	// "Pixels"
 	for (var i = 0; i < height; i++) {
 		for (var j = 0; j < width; j++) {
-			var color = bits[i * height + j] ? 'white' : 'black';
+			var white = bits[i * height + j];
+			if (!white) continue;
+
 			var pixel = document.createElement('rect');;
 			pixel.setAttribute('width', 1);
 			pixel.setAttribute('height', 1);
 			pixel.setAttribute('x', j + 1);
 			pixel.setAttribute('y', i + 1);
-			pixel.setAttribute('fill', color);
+			pixel.setAttribute('fill', 'white');
 			svg.appendChild(pixel);
+
+			if (!fixPdfArtifacts) continue;
+
+			if ((j < width - 1) && (bits[i * height + j + 1])) {
+				pixel.setAttribute('width', 1.5);
+			}
+
+			if ((i < height - 1) && (bits[(i + 1) * height + j])) {
+				var pixel2 = document.createElement('rect');;
+				pixel2.setAttribute('width', 1);
+				pixel2.setAttribute('height', 1.5);
+				pixel2.setAttribute('x', j + 1);
+				pixel2.setAttribute('y', i + 1);
+				pixel2.setAttribute('fill', 'white');
+				svg.appendChild(pixel2);
+			}
 		}
 	}
 


### PR DESCRIPTION
This workaround fixes a long-living issue with exporting the marker to PDF.

Due to peculiarities of PDF rendering on some zoom levels there might appear little gaps between marker's "pixels", that look like this:

<img width="894" alt="Screenshot 2022-03-31 at 03 45 56" src="https://user-images.githubusercontent.com/1683279/160948743-2c5be6f5-3e49-43ab-911a-c7728bc59095.png">

I guess, these artifacts might apper on a printed version of marker, which is definitely not good.

SVG's attribute `shape-rendering` set to `crispEdges` doesn't save the situation. Changing of any related SVG parameter's doesn't help as well.

This patch implements a workaround for this. For each white pixel of a marker, if there is a white pixel on the right, the width of the pixel is increased to 1.5 to overlap potential gap.

If there is a white pixel under it, another white rect is added with height 1.5 to overlap the gap as well.

Thus, the rendered PDF is guaranteed to not have such artifacts:

<img width="897" alt="Screenshot 2022-03-31 at 03 45 58" src="https://user-images.githubusercontent.com/1683279/160948758-2b779d12-4480-48ea-bd98-7cab944564d8.png">